### PR TITLE
feat: use pytest-asyncio to fix CI error on Python 3.11 and 3.12

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,5 @@ asynccasbin==1.1.7
 databases==0.7.0
 SQLAlchemy==1.4.42
 pytest>=7.3.0
-alt-pytest-asyncio>=0.7.0
+pytest-asyncio>=1.1.0
 aiosqlite>=0.19.0


### PR DESCRIPTION
The previously used alt-pytest-asyncio is incompatible with Python 3.11 and 3.12, which caused errors when running tests. pytest-asyncio is more of a standard, offers stronger compatibility, and serves as an effective replacement for alt-pytest-asyncio. Therefore, the alt-pytest-asyncio dependency has been replaced with pytest-asyncio, and a pytest.ini file has been added.